### PR TITLE
./configure needs bash

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 # ex: sts=8 sw=8 ts=8 noet
 set -eu -o pipefail
 


### PR DESCRIPTION
The `configure` script uses `set -o pipefail` which is a bash feature. The shebang should be changed.