### PR TITLE
do-rpm: build a rpm automagically

### DIFF
--- a/do-rpm
+++ b/do-rpm
@@ -10,11 +10,18 @@ else
 fi
 
 cd "$(dirname $0)"
-pv=$(git describe "$tree_ish")
+pv=$(git describe "$tree_ish" | sed -e s,-,+,g)
 ph=$(git rev-parse "$tree_ish")
+ccan_ph=$(cd ccan ; git rev-parse HEAD)
 dist=$(date +%s)
 
-# TODO: generate tarballs...
+rm -rf RPM_SOURCES
+mkdir RPM_SOURCES
+git archive --prefix="$pn"-"$ph"/ -o RPM_SOURCES/"$pn"-"$ph".tar "$tree_ish"
+gzip -9 RPM_SOURCES/"$pn"-"$ph".tar
+( cd ccan ; git archive --prefix=ccan-"$ccan_ph"/ -o ../RPM_SOURCES/ccan-"$ccan_ph".tar HEAD )
+gzip -9 RPM_SOURCES/ccan-"$ccan_ph".tar
 
-# Issue: these defines can't override the ones in the file
-rpmbuild -Dcommit="$ph" -Dver="$pv" -Ddist="$dist" -ba "$pn".spec
+sed -e s,%ver%,$pv,g -e s,%dist%,$dist,g -e s,%commit%,$ph,g -e s,%ccan_commit%,$ccan_ph,g < $pn.spec.in > RPM_SOURCES/$pn.spec
+
+rpmbuild -D_topdir" $(pwd)" -D_sourcedir" $(pwd)"/RPM_SOURCES -D_specdir" $(pwd)"/RPM_SOURCES -ba RPM_SOURCES/"$pn".spec

--- a/illum.spec.in
+++ b/illum.spec.in
@@ -1,12 +1,12 @@
 Name:           illum
-Version:        0.3
-Release:        1%{?dist}
+Version:        %ver%
+Release:        %dist%
 Summary:        A daemon that responds to brightness keys by changing the backlight level
 
 License:        AGPLv3
 URL:            https://github.com/jmesmon/illum
-%global commit 35f56ca1af82480029ba2adaba44959939b5d162
-%global ccan_commit 3ed55657aa0208046cdb5c57cc9dbb2e6300a97b
+%global commit %commit%
+%global ccan_commit %ccan_commit%
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global owner jmesmon
 Source0:        https://github.com/%{owner}/%{name}/archive/%{commit}/%{name}-%{commit}.tar.gz


### PR DESCRIPTION
This BuildsForMe(tm)

Note: this sets the rpmbuild topdir to $(pwd) so it should build out of the box even for users of distros that don't preconfigure rpmbuild with sane defaults.

The downside is that people who do configure rpmbuild get the configuration overridden for this build