### PR TITLE
do-rpm: set build flags to the rpm provided ones (instead of using dev flags)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ illum-ctl
 
 # FIXME: remove once config.h is shoved in one of the build subdirs
 config.h
+
+/BUILD/
+/RPMS/
+/SRPMS/
+/RPM_SOURCES/

--- a/do-rpm
+++ b/do-rpm
@@ -24,4 +24,4 @@ gzip -9 RPM_SOURCES/ccan-"$ccan_ph".tar
 
 sed -e s,%ver%,$pv,g -e s,%dist%,$dist,g -e s,%commit%,$ph,g -e s,%ccan_commit%,$ccan_ph,g < $pn.spec.in > RPM_SOURCES/$pn.spec
 
-rpmbuild -D_topdir" $(pwd)" -D_sourcedir" $(pwd)"/RPM_SOURCES -D_specdir" $(pwd)"/RPM_SOURCES -ba RPM_SOURCES/"$pn".spec
+rpmbuild --nodeps -D_topdir" $(pwd)" -D_sourcedir" $(pwd)"/RPM_SOURCES -D_specdir" $(pwd)"/RPM_SOURCES -ba RPM_SOURCES/"$pn".spec

--- a/illum.spec.in
+++ b/illum.spec.in
@@ -26,7 +26,8 @@ rmdir ccan
 mv $(basename %{SOURCE1} .tar.gz) ccan
 
 %build
-./build
+%set_build_flags
+./build -v
 
 %install
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Fixes #11